### PR TITLE
[FIX] mixin.js without namespaces

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -7,7 +7,7 @@ export default {
 
         if(!this.sockets) this.sockets = {};
 
-        if (typeof this.$vueSocketIo === 'object') {
+        if (this.$vueSocketIo.useConnectionNamespace) {
             for (const namespace of Object.keys(this.$vueSocketIo)) {
                 this.sockets[namespace] = {
                     subscribe: (event, callback) => {
@@ -19,8 +19,12 @@ export default {
                 }
             }
         } else {
-            this.$vueSocketIo.emitter.addListener(event, callback, this);
-            this.$vueSocketIo.emitter.removeListener(event, this);
+            this.sockets.subscribe = (event, callback) => {
+                this.$vueSocketIo.emitter.addListener(event, callback, this);
+            };
+            this.sockets.unsubscribe = (event) => {
+                this.$vueSocketIo.emitter.removeListener(event, this);
+            };
         }
     },
 
@@ -31,7 +35,7 @@ export default {
 
         if(this.$options.sockets){
 
-            if (typeof this.$vueSocketIo === 'object') {
+            if (this.$vueSocketIo.useConnectionNamespace) {
                 for (const namespace of Object.keys(this.$vueSocketIo)) {
                     if (this.$options.sockets[namespace]) {
                         Object.keys(this.$options.sockets[namespace]).forEach(event => {
@@ -63,7 +67,7 @@ export default {
 
         if(this.$options.sockets){
 
-            if (typeof this.$vueSocketIo === 'object') {
+            if (this.$vueSocketIo.useConnectionNamespace) {
                 for (const namespace of Object.keys(this.$vueSocketIo)) {
                     if (this.$options.sockets[namespace]) {
                         Object.keys(this.$options.sockets[namespace]).forEach(event => {


### PR DESCRIPTION
Mixin behaviour was incorrect when namespaces were not being used, making it impossible to subscribe to events. Now it should work as described in the documentation.